### PR TITLE
Update target names

### DIFF
--- a/audio/audio_callback/Makefile
+++ b/audio/audio_callback/Makefile
@@ -29,7 +29,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
 
-TARGET_NAME := test
+TARGET_NAME := testaudio_callback
 LIBM		= -lm
 
 ifeq ($(ARCHFLAGS),)

--- a/audio/audio_no_callback/Makefile
+++ b/audio/audio_no_callback/Makefile
@@ -29,7 +29,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
 
-TARGET_NAME := test
+TARGET_NAME := testaudio_no_callback
 LIBM		= -lm
 
 ifeq ($(ARCHFLAGS),)

--- a/graphics/opengl/libretro_test_gl_compute_shaders/Makefile
+++ b/graphics/opengl/libretro_test_gl_compute_shaders/Makefile
@@ -12,7 +12,7 @@ else ifneq ($(findstring win,$(shell uname -a)),)
 endif
 endif
 
-TARGET_NAME := boxes
+TARGET_NAME := testgl_compute_shaders
 
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
@@ -46,7 +46,7 @@ endif
 CXXFLAGS += -std=gnu++11 -Wall $(fpic) -DHAVE_ZIP_DEFLATE
 CFLAGS += -std=gnu99 -Wall $(fpic) -DHAVE_ZIP_DEFLATE
 
-SOURCES := $(wildcard libretro/*.cpp) $(wildcard gl/*.cpp) app/$(TARGET_NAME).cpp
+SOURCES := $(wildcard libretro/*.cpp) $(wildcard gl/*.cpp) $(wildcard app/*.cpp)
 CSOURCES = $(wildcard rpng/*.c) glsym/rglgen.c
 LIBS += $(GL_LIB) 
 CSOURCES += glsym/glsym_gl.c

--- a/graphics/software/rendering/Makefile
+++ b/graphics/software/rendering/Makefile
@@ -29,7 +29,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
 
-TARGET_NAME := test
+TARGET_NAME := testsw
 LIBM		= -lm
 
 ifeq ($(ARCHFLAGS),)

--- a/graphics/software/rendering_direct_to_vram/Makefile
+++ b/graphics/software/rendering_direct_to_vram/Makefile
@@ -29,7 +29,7 @@ else ifneq ($(findstring MINGW,$(shell uname -a)),)
 	system_platform = win
 endif
 
-TARGET_NAME := test
+TARGET_NAME := testsw_vram
 LIBM		= -lm
 
 ifeq ($(ARCHFLAGS),)


### PR DESCRIPTION
Its annoying having multiple test cores build under the same target name (i.e. `test_libretro.so`), so this changes some which did not have unique names.
