### PR TITLE
Remove extra .gitignore

### DIFF
--- a/graphics/opengl/libretro_test_gl_compute_shaders/.gitignore
+++ b/graphics/opengl/libretro_test_gl_compute_shaders/.gitignore
@@ -1,4 +1,0 @@
-*.o
-*.so
-*.dll
-*.dylib


### PR DESCRIPTION
I missed this earlier `.gitignore` in `graphics/opengl/libretro_test_gl_compute_shaders`, it unfortunately misses all of the other sample directories not to mention it is now redundant. Its a lot easier to maintain one `.gitignore` than many so lets just remove this.
