### PR TITLE
Use DEBUG=1 properly for some Makefiles

### DIFF
--- a/demos/game/cruzes/Makefile
+++ b/demos/game/cruzes/Makefile
@@ -26,10 +26,10 @@ idirs  := -I.
 cflags := -Wall -std=c99
 fpic   := -fPIC
 
-cflags_debug   := -g
-cflags_release := -O2 -g
+cflags_debug   := -O0 -g
+cflags_release := -O2
 
-ifneq ($(findstring debug,$(config)),)
+ifeq ($(DEBUG), 1)
 	cflags += $(cflags_debug)
 else
 	cflags += $(cflags_release)

--- a/graphics/opengl/libretro_test_gl_compute_shaders/Makefile
+++ b/graphics/opengl/libretro_test_gl_compute_shaders/Makefile
@@ -39,8 +39,8 @@ ifeq ($(DEBUG), 1)
    CXXFLAGS += -O0 -g -DGL_DEBUG
    CFLAGS += -O0 -g
 else
-   CXXFLAGS += -O3 -g
-   CFLAGS += -O3 -g
+   CXXFLAGS += -O3 -DNDEBUG
+   CFLAGS += -O3 -DNDEBUG
 endif
 
 CXXFLAGS += -std=gnu++11 -Wall $(fpic) -DHAVE_ZIP_DEFLATE


### PR DESCRIPTION
I noticed two of the sample cores do not use `DEBUG=1` properly, this makes it so that it works as expected.
