### PR TITLE
(freebasic) Fix typos

### DIFF
--- a/lang/freebasic/README.md
+++ b/lang/freebasic/README.md
@@ -2,9 +2,9 @@
 A test core written in FreeBasic for libretro.
 
 ## Programming language
-Pascal
+Basic
 
 ## Building
 To compile, you will need FreeBasic installed.
 
-	fpc -dll fbastest.bas
+	fbc -dll fbastest.bas


### PR DESCRIPTION
The freebasic sample core requires `fbc` to build, not `fpc`. It also is in basic, not pascal.