### PR TITLE
(freebasic) Improve build instructions to match other core names.

### DIFF
--- a/lang/freebasic/README.md
+++ b/lang/freebasic/README.md
@@ -7,4 +7,4 @@ Basic
 ## Building
 To compile, you will need FreeBasic installed.
 
-	fbc -dll fbastest.bas
+	fbc -dll fbastest.bas -x freebasic_libretro.so

--- a/lang/freebasic/fbastest.bas
+++ b/lang/freebasic/fbastest.bas
@@ -1,9 +1,9 @@
 ' 
 ' BUILDING
-'    Run "fbc -dll fbastest.bas"
+'    Run "fbc -dll fbastest.bas -x freebasic_libretro.so"
 '
 ' RUNNING
-'    ./retroarch -L libfbastest.so
+'    ./retroarch -L freebasic_libretro.so
 '
 #lang "fb"
 


### PR DESCRIPTION
This improves the build instructions so that the compiled library will be more consistent with other core library names. So instead of `libfbastest.so` it will now be `freebasic_libretro.so`.